### PR TITLE
Remove dependency on javax.mail.dsn

### DIFF
--- a/application/org.openjdk.jmc.feature.core/feature.xml
+++ b/application/org.openjdk.jmc.feature.core/feature.xml
@@ -174,11 +174,6 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="javax.mail.dsn"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+ 
 
 </feature>

--- a/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
+++ b/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
@@ -38,7 +38,6 @@
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="com.sun.mail.jakarta.mail" version="1.6.3"/>
             <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="javax.mail.dsn" version="1.4.0"/>
             <unit id="org.owasp.encoder" version="1.2.2"/>
             <unit id="org.lz4.lz4-java" version="1.7.1"/>
             <unit id="org.twitter4j.core" version="4.0.7"/>

--- a/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
+++ b/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
@@ -38,7 +38,6 @@
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="com.sun.mail.jakarta.mail" version="1.6.3"/>
             <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="javax.mail.dsn" version="1.4.0"/>
             <unit id="org.owasp.encoder" version="1.2.2"/>
             <unit id="org.lz4.lz4-java" version="1.7.1"/>
             <unit id="org.twitter4j.core" version="4.0.7"/>

--- a/releng/platform-definitions/platform-definition-photon/platform-definition-photon.target
+++ b/releng/platform-definitions/platform-definition-photon/platform-definition-photon.target
@@ -37,7 +37,6 @@
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="com.sun.mail.jakarta.mail" version="1.6.3"/>
             <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="javax.mail.dsn" version="1.4.0"/>
             <unit id="org.owasp.encoder" version="1.2.2"/>
             <unit id="org.lz4.lz4-java" version="1.7.1"/>
             <unit id="org.twitter4j.core" version="4.0.7"/>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -72,9 +72,6 @@
 									<id>com.sun.activation:jakarta.activation:1.2.1</id>
 								</artifact>
 								<artifact>
-									<id>javax.mail:dsn:1.4</id>
-								</artifact>
-								<artifact>
 									<id>org.owasp.encoder:encoder:1.2.2</id>
 								</artifact>
 								<artifact>


### PR DESCRIPTION
Workaround for a third party maven repo which is off the air:

  http://repository.ops4j.org/maven2/

Reported:

 https://groups.google.com/forum/#!msg/ops4j/BL6zQUSLFBM/8QPTDbCGBQAJ